### PR TITLE
Explicitly cast MultiLabelTextProcessor examples to string

### DIFF
--- a/fast_bert/data_cls.py
+++ b/fast_bert/data_cls.py
@@ -345,7 +345,7 @@ class MultiLabelTextProcessor(TextProcessor):
             return list(
                 df.apply(
                     lambda row: InputExample(
-                        guid=row.index, text_a=row[text_col], label=[]
+                        guid=row.index, text_a=str(row[text_col]), label=[]
                     ),
                     axis=1,
                 )
@@ -355,7 +355,7 @@ class MultiLabelTextProcessor(TextProcessor):
                 df.apply(
                     lambda row: InputExample(
                         guid=row.index,
-                        text_a=row[text_col],
+                        text_a=str(row[text_col]),
                         label=_get_labels(row, label_col),
                     ),
                     axis=1,


### PR DESCRIPTION
When training on SageMaker, the input examples aren't cast to string causing TypeError: expected string or bytes-like object (see issue #158 ).

This pull request explicitly casts input text to string for multi-label classification (I hadn't tested multi-label before pull request #167).