### PR TITLE
Remove python built-in to fix installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ tokenizers==0.8.1.rc1
 transformers>=3.0.2
 pandas
 python-box
-itertools
 more_itertools


### PR DESCRIPTION
Having itertools in the requirements.txt break installation since it is a python built-in