### PR TITLE
Remove gevent package

### DIFF
--- a/container_lm/Dockerfile
+++ b/container_lm/Dockerfile
@@ -54,7 +54,6 @@ RUN pip --no-cache-dir install \
     flask \
     pathlib \
     gunicorn \
-    gevent \
     scipy \
     sklearn \
     pandas \


### PR DESCRIPTION
Removes gevent package from pip installation, as it was from a legacy version of the container