### PR TITLE
Updated learner_util.py save_model() to work with an alternate path

### DIFF
--- a/fast_bert/learner_util.py
+++ b/fast_bert/learner_util.py
@@ -128,6 +128,8 @@ class Learner(object):
 
         if not path:
             path = self.output_dir / "model_out"
+        else:
+            path = Path(path)
 
         path.mkdir(exist_ok=True)
 


### PR DESCRIPTION
Currently when a path string is provided to `learner.save_model()`, a directory is not created. This hotfix converts the string to a `Path` object so that a new directory can be created.